### PR TITLE
RESTORE: Pagination, Pane, ProgressCircle, Tag and Tooltip

### DIFF
--- a/src/core/progress/circle.tsx
+++ b/src/core/progress/circle.tsx
@@ -52,11 +52,10 @@ const getStroke = (props: ProgressCircleProps) => {
 /**
  * A progress circle informs users that an operation is in progress, and often
  * how far it has been progressed. It is also known as [throbber][1], and is
- * a type of [progress indicator][2] (along with [progress bar][3]).
+ * a type of [progress indicator][2] (along with progress bar).
  *
  * [1]: https://en.wikipedia.org/wiki/Throbber
  * [2]: https://en.wikipedia.org/wiki/Progress_indicator
- * [3]: /docs/components-progress-bar--primary
  */
 export const ProgressCircle = (props: ProgressCircleProps): JSX.Element => {
   const stroke = getStroke(props);

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -1,14 +1,15 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { useCallback, useState } from "react";
-import { Utils } from "../utils/utils";
 import { Pagination } from "../../core";
+import { docsMetaParameters } from "../utils/parameter";
 
 const meta: Meta = {
   title: "Components/Pagination",
   component: Pagination,
+  parameters: docsMetaParameters({
+    primary: 'none'
+  })
 };
-
-Utils.page.component(meta, { primary: "none", shots: [] });
 
 export default meta;
 

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -1,0 +1,78 @@
+import { Meta } from "@storybook/react";
+import { useCallback, useState } from "react";
+import { Pagination } from "../../../core/src";
+import { Utils } from "../utils/utils";
+
+const meta: Meta = {
+  title: "Components/Pagination",
+  component: Pagination,
+};
+
+Utils.page.component(meta, { primary: "none", shots: [] });
+
+export default meta;
+
+export const Primary = (): JSX.Element => {
+  const [page, setPage] = useState(1);
+  return <Pagination value={page} setValue={setPage} max={10} min={1} />;
+};
+
+export const Basic = Primary;
+
+Utils.story(Basic, {
+  desc: `
+Pagination is a [controlled][1] component. You should maintain a number
+[state][2] for the current page, and pass the control to a pagination via its
+\`value\` and \`setValue\` props. It also requires the \`min\` and \`max\`
+props (inclusive) to define the range of pages users can go to.
+
+[1]: https://reactjs.org/docs/forms.html#controlled-components
+[2]: https://reactjs.org/docs/hooks-state.html
+`,
+});
+
+export const Async = (): JSX.Element => {
+  const [page, setPage] = useState(1);
+  const setPageAsync = useCallback((page): Promise<void> => {
+    return new Promise((resolve) => {
+      setPage(page);
+      window.setTimeout(() => resolve(), 1000);
+    });
+  }, []);
+  return <Pagination value={page} setValue={setPageAsync} max={10} min={1} />;
+};
+
+Utils.story(Async, {
+  desc: `
+You may need to fetch some new data when users navigate to a new page. In these
+cases, return a [\`Promise\`][1] in the \`setValue\` callback to have the
+pagination displays a loading state while waiting for data.
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+`,
+});
+
+export const Counting = (): JSX.Element => {
+  // Zero-based API
+  const TOTAL_PAGES = 9;
+  const [page, setPage] = useState(0);
+
+  // One-based UI
+  return (
+    <Pagination
+      value={page + 1}
+      setValue={(page) => setPage(page - 1)}
+      max={TOTAL_PAGES + 1}
+      min={1}
+    />
+  );
+};
+
+Utils.story(Counting, {
+  desc: `
+In most cases, paginations should start at "1" to mimic real-life counting.
+However, your pagination back end may start at "0". In these cases, it's
+recommended to use zero-based counting for your state and most logic, and only
+translate to one-based in the pagination's props.
+`,
+});

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { useCallback, useState } from "react";
-import { Pagination } from "../../../core/src";
 import { Utils } from "../utils/utils";
+import { Pagination } from "../../core";
 
 const meta: Meta = {
   title: "Components/Pagination",
@@ -12,9 +12,11 @@ Utils.page.component(meta, { primary: "none", shots: [] });
 
 export default meta;
 
-export const Primary = (): JSX.Element => {
-  const [page, setPage] = useState(1);
-  return <Pagination value={page} setValue={setPage} max={10} min={1} />;
+export const Primary: StoryObj<typeof Pagination> = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    return <Pagination value={page} setValue={setPage} max={10} min={1} />;
+  }
 };
 
 export const Basic = Primary;
@@ -31,15 +33,17 @@ props (inclusive) to define the range of pages users can go to.
 `,
 });
 
-export const Async = (): JSX.Element => {
-  const [page, setPage] = useState(1);
-  const setPageAsync = useCallback((page): Promise<void> => {
-    return new Promise((resolve) => {
-      setPage(page);
-      window.setTimeout(() => resolve(), 1000);
-    });
-  }, []);
-  return <Pagination value={page} setValue={setPageAsync} max={10} min={1} />;
+export const Async: StoryObj = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    const setPageAsync = useCallback((page: number): Promise<void> => {
+      return new Promise((resolve) => {
+        setPage(page);
+        window.setTimeout(() => resolve(), 1000);
+      });
+    }, []);
+    return <Pagination value={page} setValue={setPageAsync} max={10} min={1} />;
+  }
 };
 
 Utils.story(Async, {
@@ -52,20 +56,22 @@ pagination displays a loading state while waiting for data.
 `,
 });
 
-export const Counting = (): JSX.Element => {
-  // Zero-based API
-  const TOTAL_PAGES = 9;
-  const [page, setPage] = useState(0);
+export const Counting: StoryObj = {
+  render: () => {
+    // Zero-based API
+    const TOTAL_PAGES = 9;
+    const [page, setPage] = useState(0);
 
-  // One-based UI
-  return (
-    <Pagination
-      value={page + 1}
-      setValue={(page) => setPage(page - 1)}
-      max={TOTAL_PAGES + 1}
-      min={1}
-    />
-  );
+    // One-based UI
+    return (
+      <Pagination
+        value={page + 1}
+        setValue={(page) => setPage(page - 1)}
+        max={TOTAL_PAGES + 1}
+        min={1}
+      />
+    );
+  }
 };
 
 Utils.story(Counting, {

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -20,10 +20,10 @@ export const Primary: StoryObj<typeof Pagination> = {
 };
 
 /**
- * Pagination is a [controlled][1] component. You should maintain a number
- * [state][2] for the current page, and pass the control to a pagination via its
- * `value` and `setValue` props. It also requires the `min` and `max`
- * props (inclusive) to define the range of pages users can go to.
+ * Pagination is a [controlled][1] component.
+ * You should maintain a number [state][2] for the current page,
+ * and pass the control to a pagination via its `value` and `setValue` props.
+ * It also requires the `min` and `max` props (inclusive) to define the range of pages users can go to.
  *
  * [1]: https://reactjs.org/docs/forms.html#controlled-components
  * [2]: https://reactjs.org/docs/hooks-state.html
@@ -31,9 +31,9 @@ export const Primary: StoryObj<typeof Pagination> = {
 export const Basic = Primary
 
 /**
- * You may need to fetch some new data when users navigate to a new page. In these
- * cases, return a `Promise` in the `setValue` callback to have the
- * pagination displays a loading state while waiting for data.
+ * You may need to fetch some new data when users navigate to a new page.
+ * In these cases,
+ * return a `Promise` in the `setValue` callback to have the pagination displays a loading state while waiting for data.
  *
  * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
  */
@@ -52,9 +52,10 @@ export const Async: StoryObj = {
 
 /**
  * In most cases, paginations should start at "1" to mimic real-life counting.
- * However, your pagination back end may start at "0". In these cases, it's
- * recommended to use zero-based counting for your state and most logic, and only
- * translate to one-based in the pagination's props.
+ * However, your pagination back end may start at "0".
+ * In these cases,
+ * it's recommended to use zero-based counting for your state and most logic,
+ * and only translate to one-based in the pagination's props.
  */
 export const Counting: StoryObj = {
   render: () => {

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -19,20 +19,24 @@ export const Primary: StoryObj<typeof Pagination> = {
   }
 };
 
-export const Basic = Primary;
+/**
+ * Pagination is a [controlled][1] component. You should maintain a number
+ * [state][2] for the current page, and pass the control to a pagination via its
+ * `value` and `setValue` props. It also requires the `min` and `max`
+ * props (inclusive) to define the range of pages users can go to.
+ *
+ * [1]: https://reactjs.org/docs/forms.html#controlled-components
+ * [2]: https://reactjs.org/docs/hooks-state.html
+ */
+export const Basic = Primary
 
-Utils.story(Basic, {
-  desc: `
-Pagination is a [controlled][1] component. You should maintain a number
-[state][2] for the current page, and pass the control to a pagination via its
-\`value\` and \`setValue\` props. It also requires the \`min\` and \`max\`
-props (inclusive) to define the range of pages users can go to.
-
-[1]: https://reactjs.org/docs/forms.html#controlled-components
-[2]: https://reactjs.org/docs/hooks-state.html
-`,
-});
-
+/**
+ * You may need to fetch some new data when users navigate to a new page. In these
+ * cases, return a `Promise` in the `setValue` callback to have the
+ * pagination displays a loading state while waiting for data.
+ *
+ * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+ */
 export const Async: StoryObj = {
   render: () => {
     const [page, setPage] = useState(1);
@@ -46,16 +50,12 @@ export const Async: StoryObj = {
   }
 };
 
-Utils.story(Async, {
-  desc: `
-You may need to fetch some new data when users navigate to a new page. In these
-cases, return a [\`Promise\`][1] in the \`setValue\` callback to have the
-pagination displays a loading state while waiting for data.
-
-[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-`,
-});
-
+/**
+ * In most cases, paginations should start at "1" to mimic real-life counting.
+ * However, your pagination back end may start at "0". In these cases, it's
+ * recommended to use zero-based counting for your state and most logic, and only
+ * translate to one-based in the pagination's props.
+ */
 export const Counting: StoryObj = {
   render: () => {
     // Zero-based API
@@ -73,12 +73,3 @@ export const Counting: StoryObj = {
     );
   }
 };
-
-Utils.story(Counting, {
-  desc: `
-In most cases, paginations should start at "1" to mimic real-life counting.
-However, your pagination back end may start at "0". In these cases, it's
-recommended to use zero-based counting for your state and most logic, and only
-translate to one-based in the pagination's props.
-`,
-});

--- a/src/docs/components/pagination.stories.tsx
+++ b/src/docs/components/pagination.stories.tsx
@@ -34,7 +34,7 @@ export const Basic = Primary
 /**
  * You may need to fetch some new data when users navigate to a new page.
  * In these cases,
- * return a `Promise` in the `setValue` callback to have the pagination displays a loading state while waiting for data.
+ * return a [`Promise`][1] in the `setValue` callback to have the pagination displays a loading state while waiting for data.
  *
  * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
  */

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta } from "@storybook/react";
+import { Pane } from "../../../core/src";
+import { Utils } from "../utils/utils";
+
+const meta: Meta = {
+  title: "Components/Pane",
+  component: Pane,
+  argTypes: {
+    children: Utils.arg("React.ReactNode"),
+    noPadding: Utils.arg("boolean"),
+    fullHeight: Utils.arg("boolean"),
+    contentWidth: Utils.arg("boolean"),
+  },
+};
+
+Utils.page.component(meta, {
+  primary: "sticky",
+  shots: [],
+});
+
+export default meta;
+
+interface Props {
+  noPadding?: boolean;
+  fullHeight?: boolean;
+  contentWidth?: boolean;
+}
+
+export const Primary = (props: Props): JSX.Element => (
+  <div style={{ height: 100 }}>
+    <Pane {...props}>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+    </Pane>
+  </div>
+);
+
+export const Basic = (): JSX.Element => (
+  <Pane>
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Temporibus
+    sapiente vero ad eius fuga atque repellendus? Repellat sint veniam adipisci
+    accusamus, nihil explicabo odio, id neque ducimus voluptate nulla? Maiores?
+  </Pane>
+);
+
+Utils.story(Basic, {
+  desc: `
+A pane only require its \`children\` to be defined. See the [props table][1]
+below for props to control its padding, width and height.
+
+[1]: #props
+`,
+});

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -1,16 +1,18 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Utils } from "../utils/utils";
 import { Pane } from "../../core";
+import { docsMetaArgTypes } from "../utils/arg-type";
 
 const meta: Meta = {
   title: "Components/Pane",
   component: Pane,
-  argTypes: {
-    children: Utils.arg("React.ReactNode"),
-    noPadding: Utils.arg("boolean"),
-    fullHeight: Utils.arg("boolean"),
-    contentWidth: Utils.arg("boolean"),
-  },
+  argTypes: docsMetaArgTypes({
+    "": {
+      children: false,
+      noPadding: "boolean",
+      fullHeight: "boolean",
+      contentWidth: "boolean",
+    }
+  })
 };
 
 export default meta;

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -31,8 +31,8 @@ export const Primary: StoryObj<typeof Pane> = {
 };
 
 /**
- * A pane only require its `children` to be defined. See the [props table][1]
- * below for props to control its padding, width and height.
+ * A pane only require its `children` to be defined.
+ * See the [props table][1] below for props to control its padding, width and height.
  *
  * [1]: #props
  */

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -13,11 +13,6 @@ const meta: Meta = {
   },
 };
 
-Utils.page.component(meta, {
-  primary: "sticky",
-  shots: [],
-});
-
 export default meta;
 
 export const Primary: StoryObj<typeof Pane> = {

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -1,6 +1,6 @@
-import { Meta } from "@storybook/react";
-import { Pane } from "../../../core/src";
+import { Meta, StoryObj } from "@storybook/react";
 import { Utils } from "../utils/utils";
+import { Pane } from "../../core";
 
 const meta: Meta = {
   title: "Components/Pane",
@@ -20,27 +20,25 @@ Utils.page.component(meta, {
 
 export default meta;
 
-interface Props {
-  noPadding?: boolean;
-  fullHeight?: boolean;
-  contentWidth?: boolean;
-}
+export const Primary: StoryObj<typeof Pane> = {
+  render: (props) => (
+    <div style={{ height: 100 }}>
+      <Pane {...props}>
+        Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+      </Pane>
+    </div>
+  )
+};
 
-export const Primary = (props: Props): JSX.Element => (
-  <div style={{ height: 100 }}>
-    <Pane {...props}>
-      Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+export const Basic: StoryObj = {
+  render: () => (
+    <Pane>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Temporibus
+      sapiente vero ad eius fuga atque repellendus? Repellat sint veniam adipisci
+      accusamus, nihil explicabo odio, id neque ducimus voluptate nulla? Maiores?
     </Pane>
-  </div>
-);
-
-export const Basic = (): JSX.Element => (
-  <Pane>
-    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Temporibus
-    sapiente vero ad eius fuga atque repellendus? Repellat sint veniam adipisci
-    accusamus, nihil explicabo odio, id neque ducimus voluptate nulla? Maiores?
-  </Pane>
-);
+  )
+};
 
 Utils.story(Basic, {
   desc: `

--- a/src/docs/components/pane.stories.tsx
+++ b/src/docs/components/pane.stories.tsx
@@ -30,6 +30,12 @@ export const Primary: StoryObj<typeof Pane> = {
   )
 };
 
+/**
+ * A pane only require its `children` to be defined. See the [props table][1]
+ * below for props to control its padding, width and height.
+ *
+ * [1]: #props
+ */
 export const Basic: StoryObj = {
   render: () => (
     <Pane>
@@ -39,12 +45,3 @@ export const Basic: StoryObj = {
     </Pane>
   )
 };
-
-Utils.story(Basic, {
-  desc: `
-A pane only require its \`children\` to be defined. See the [props table][1]
-below for props to control its padding, width and height.
-
-[1]: #props
-`,
-});

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -1,0 +1,76 @@
+import { Meta } from "@storybook/react";
+import { ProgressCircle, ProgressCircleProps } from "../../../core/src";
+import { GalleryProgress } from "../../../gallery/src";
+import { Utils } from "../utils/utils";
+
+const meta: Meta = {
+  title: "Components/Progress Circle",
+  component: ProgressCircle,
+  argTypes: {
+    size: Utils.arg("number"),
+    value: Utils.arg("number"),
+    color: Utils.arg(ProgressCircle.colors),
+  },
+};
+
+Utils.page.component(meta, {
+  primary: "sticky",
+  shots: [<GalleryProgress key="1" />],
+});
+
+export default meta;
+
+interface Props {
+  size: number;
+  value: number;
+  color?: string;
+}
+
+export const Primary = (props: Props): JSX.Element => (
+  <ProgressCircle
+    size={props.size ?? 16}
+    value={props.value ?? 0.4}
+    // eslint-disable-next-line
+    color={(ProgressCircle.colors as any)[props.color!]}
+  />
+);
+
+export const Basic = (): JSX.Element => (
+  <div style={{ display: "flex", gap: 8 }}>
+    <ProgressCircle size={16} value={0.4} />
+    <ProgressCircle size={16} value="indeterminate" />
+  </div>
+);
+
+Utils.story(Basic, {
+  desc: `
+A progress circle requires its \`size\` and \`value\` props to be defined. The
+value should be a number from 0 (no progress yet) to 1 (all's done), or the
+"indeterminate" string to show a spinning circle.
+`,
+});
+
+export const Color = (): JSX.Element => {
+  const base: ProgressCircleProps = { size: 16, value: "indeterminate" };
+  const { neutral, highlight, inverse } = ProgressCircle.colors;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <ProgressCircle {...base} color={neutral} />
+      <ProgressCircle {...base} color={highlight} />
+      <div style={{ background: "var(--highlight-5)", padding: 8 }}>
+        <ProgressCircle {...base} color={inverse} />
+      </div>
+    </div>
+  );
+};
+
+Utils.story(Color, {
+  desc: `
+The color of a progress circle is set via its \`color\` prop. Colors are
+defined at \`ProgressCircle.colors\`:
+
+- \`neutral\` shows a gray circle. This is the default value.
+- \`highlight\` highlight the circle.
+- \`inverse\` is for displaying the circle on top of a colored background.
+`,
+});

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta } from "@storybook/react";
-import { ProgressCircle, ProgressCircleProps } from "../../../core/src";
+import { Meta, StoryObj } from "@storybook/react";
 import { GalleryProgress } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
+import { ProgressCircle, ProgressCircleProps } from "../../core";
 
 const meta: Meta = {
   title: "Components/Progress Circle",
@@ -20,27 +20,24 @@ Utils.page.component(meta, {
 
 export default meta;
 
-interface Props {
-  size: number;
-  value: number;
-  color?: string;
-}
+export const Primary: StoryObj<typeof ProgressCircle> = {
+  render: (props) => (
+    <ProgressCircle
+      size={props.size ?? 16}
+      value={props.value ?? 0.4}
+      color={props.color}
+    />
+  )
+};
 
-export const Primary = (props: Props): JSX.Element => (
-  <ProgressCircle
-    size={props.size ?? 16}
-    value={props.value ?? 0.4}
-    // eslint-disable-next-line
-    color={(ProgressCircle.colors as any)[props.color!]}
-  />
-);
-
-export const Basic = (): JSX.Element => (
-  <div style={{ display: "flex", gap: 8 }}>
-    <ProgressCircle size={16} value={0.4} />
-    <ProgressCircle size={16} value="indeterminate" />
-  </div>
-);
+export const Basic: StoryObj = {
+  render: () => (
+    <div style={{ display: "flex", gap: 8 }}>
+      <ProgressCircle size={16} value={0.4} />
+      <ProgressCircle size={16} value="indeterminate" />
+    </div>
+  )
+};
 
 Utils.story(Basic, {
   desc: `
@@ -50,18 +47,20 @@ value should be a number from 0 (no progress yet) to 1 (all's done), or the
 `,
 });
 
-export const Color = (): JSX.Element => {
-  const base: ProgressCircleProps = { size: 16, value: "indeterminate" };
-  const { neutral, highlight, inverse } = ProgressCircle.colors;
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-      <ProgressCircle {...base} color={neutral} />
-      <ProgressCircle {...base} color={highlight} />
-      <div style={{ background: "var(--highlight-5)", padding: 8 }}>
-        <ProgressCircle {...base} color={inverse} />
+export const Color: StoryObj = {
+  render: () => {
+    const base: ProgressCircleProps = { size: 16, value: "indeterminate" };
+    const { neutral, highlight, inverse } = ProgressCircle.colors;
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <ProgressCircle {...base} color={neutral} />
+        <ProgressCircle {...base} color={highlight} />
+        <div style={{ background: "var(--highlight-5)", padding: 8 }}>
+          <ProgressCircle {...base} color={inverse} />
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 };
 
 Utils.story(Color, {

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -1,22 +1,21 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { GalleryProgress } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 import { ProgressCircle, ProgressCircleProps } from "../../core";
+import { docsMetaParameters } from "../utils/parameter";
+import { GalleryProgress } from "../../gallery";
 
 const meta: Meta = {
   title: "Components/Progress Circle",
   component: ProgressCircle,
+  parameters: docsMetaParameters({
+    gallery: <GalleryProgress />
+  }),
   argTypes: {
     size: Utils.arg("number"),
     value: Utils.arg("number"),
     color: Utils.arg(ProgressCircle.colors),
   },
 };
-
-Utils.page.component(meta, {
-  primary: "sticky",
-  shots: [<GalleryProgress key="1" />],
-});
 
 export default meta;
 

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -31,9 +31,9 @@ export const Primary: StoryObj<typeof ProgressCircle> = {
 };
 
 /**
- * A progress circle requires its `size` and `value` props to be defined. The
- * value should be a number from 0 (no progress yet) to 1 (all's done), or the
- * "indeterminate" string to show a spinning circle.
+ * A progress circle requires its `size` and `value` props to be defined.
+ * The value should be a number from 0 (no progress yet) to 1 (all's done),
+ * or the "indeterminate" string to show a spinning circle.
  */
 export const Basic: StoryObj = {
   render: () => (
@@ -45,8 +45,8 @@ export const Basic: StoryObj = {
 };
 
 /**
- * The color of a progress circle is set via its `color` prop. Colors are
- * defined at `ProgressCircle.colors`:
+ * The color of a progress circle is set via its `color` prop.
+ * Colors are defined at `ProgressCircle.colors`:
  *
  * - `neutral` shows a gray circle. This is the default value.
  * - `highlight` highlight the circle.

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Utils } from "../utils/utils";
 import { ProgressCircle, ProgressCircleProps } from "../../core";
 import { docsMetaParameters } from "../utils/parameter";
 import { GalleryProgress } from "../../gallery";
+import { docsMetaArgTypes } from "../utils/arg-type";
 
 const meta: Meta = {
   title: "Components/Progress Circle",
@@ -10,11 +10,13 @@ const meta: Meta = {
   parameters: docsMetaParameters({
     gallery: <GalleryProgress />
   }),
-  argTypes: {
-    size: Utils.arg("number"),
-    value: Utils.arg("number"),
-    color: Utils.arg(ProgressCircle.colors),
-  },
+  argTypes: docsMetaArgTypes({
+    "": {
+      size: "number",
+      value: "number",
+      color: ProgressCircle.colors,
+    }
+  })
 };
 
 export default meta;

--- a/src/docs/components/progress-circle.stories.tsx
+++ b/src/docs/components/progress-circle.stories.tsx
@@ -30,6 +30,11 @@ export const Primary: StoryObj<typeof ProgressCircle> = {
   )
 };
 
+/**
+ * A progress circle requires its `size` and `value` props to be defined. The
+ * value should be a number from 0 (no progress yet) to 1 (all's done), or the
+ * "indeterminate" string to show a spinning circle.
+ */
 export const Basic: StoryObj = {
   render: () => (
     <div style={{ display: "flex", gap: 8 }}>
@@ -39,14 +44,14 @@ export const Basic: StoryObj = {
   )
 };
 
-Utils.story(Basic, {
-  desc: `
-A progress circle requires its \`size\` and \`value\` props to be defined. The
-value should be a number from 0 (no progress yet) to 1 (all's done), or the
-"indeterminate" string to show a spinning circle.
-`,
-});
-
+/**
+ * The color of a progress circle is set via its `color` prop. Colors are
+ * defined at `ProgressCircle.colors`:
+ *
+ * - `neutral` shows a gray circle. This is the default value.
+ * - `highlight` highlight the circle.
+ * - `inverse` is for displaying the circle on top of a colored background.
+ */
 export const Color: StoryObj = {
   render: () => {
     const base: ProgressCircleProps = { size: 16, value: "indeterminate" };
@@ -62,14 +67,3 @@ export const Color: StoryObj = {
     );
   }
 };
-
-Utils.story(Color, {
-  desc: `
-The color of a progress circle is set via its \`color\` prop. Colors are
-defined at \`ProgressCircle.colors\`:
-
-- \`neutral\` shows a gray circle. This is the default value.
-- \`highlight\` highlight the circle.
-- \`inverse\` is for displaying the circle on top of a colored background.
-`,
-});

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -1,11 +1,15 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Utils } from "../utils/utils";
-import { GalleryTag } from "../../../gallery/src";
 import { Tag } from "../../core";
+import { docsMetaParameters } from "../utils/parameter";
+import { GalleryTag } from "../../gallery";
 
 const meta: Meta = {
   title: "Components/Tag",
   component: Tag,
+  parameters: docsMetaParameters({
+    gallery: <GalleryTag />
+  }),
   argTypes: {
     children: Utils.arg(null),
     color: Utils.arg(Tag.colors),
@@ -13,11 +17,6 @@ const meta: Meta = {
     forwardedRef: Utils.arg(null),
   },
 };
-
-Utils.page.component(meta, {
-  primary: "sticky",
-  shots: [<GalleryTag key="1" />],
-});
 
 export default meta;
 

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta } from "@storybook/react";
+import { Tag } from "../../../core/src";
+import { Utils } from "../utils/utils";
+import { GalleryTag } from "../../../gallery/src";
+
+const meta: Meta = {
+  title: "Components/Tag",
+  component: Tag,
+  argTypes: {
+    children: Utils.arg(null),
+    color: Utils.arg(Tag.colors),
+    size: Utils.arg(Tag.sizes),
+    forwardedRef: Utils.arg(null),
+  },
+};
+
+Utils.page.component(meta, {
+  primary: "sticky",
+  shots: [<GalleryTag key="1" />],
+});
+
+export default meta;
+
+interface Props {
+  color?: string;
+}
+
+export const Primary = (props: Props): JSX.Element => (
+  <Tag
+    // eslint-disable-next-line
+    color={(Tag.colors as any)[props.color ?? "gray"]}
+    children="Foo"
+  />
+);
+
+export const Basic = (): JSX.Element => <Tag color={Tag.colors.green}>Foo</Tag>;
+
+Utils.story(Basic, {
+  desc: `
+A tag requires a label, defined as a string via the \`children\` prop, and a
+color, defined via the same name prop, and should come from the \`Tag.colors\`
+list. You can try all available colors in the [All Props][1] table below.
+
+[1]: #props
+`,
+});

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta } from "@storybook/react";
-import { Tag } from "../../../core/src";
+import { Meta, StoryObj } from "@storybook/react";
 import { Utils } from "../utils/utils";
 import { GalleryTag } from "../../../gallery/src";
+import { Tag } from "../../core";
 
 const meta: Meta = {
   title: "Components/Tag",
@@ -21,19 +21,18 @@ Utils.page.component(meta, {
 
 export default meta;
 
-interface Props {
-  color?: string;
-}
+export const Primary: StoryObj<typeof Tag> = {
+  render: (props) => (
+    <Tag
+      color={props.color ?? Tag.colors.gray}
+      children="Foo"
+    />
+  )
+};
 
-export const Primary = (props: Props): JSX.Element => (
-  <Tag
-    // eslint-disable-next-line
-    color={(Tag.colors as any)[props.color ?? "gray"]}
-    children="Foo"
-  />
-);
-
-export const Basic = (): JSX.Element => <Tag color={Tag.colors.green}>Foo</Tag>;
+export const Basic: StoryObj = {
+  render: () => <Tag color={Tag.colors.green}>Foo</Tag>
+};
 
 Utils.story(Basic, {
   desc: `

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -31,9 +31,9 @@ export const Primary: StoryObj<typeof Tag> = {
 };
 
 /**
- * A tag requires a label, defined as a string via the `children` prop, and a
- * color, defined via the same name prop, and should come from the `Tag.colors`
- * list. You can try all available colors in the [All Props][1] table below.
+ * A tag requires a label, defined as a string via the `children` prop,
+ * and a color, defined via the same name prop, and should come from the `Tag.colors` list.
+ * You can try all available colors in the [All Props][1] table below.
  *
  * [1]: #props
  */

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -30,16 +30,13 @@ export const Primary: StoryObj<typeof Tag> = {
   )
 };
 
+/**
+ * A tag requires a label, defined as a string via the `children` prop, and a
+ * color, defined via the same name prop, and should come from the `Tag.colors`
+ * list. You can try all available colors in the [All Props][1] table below.
+ *
+ * [1]: #props
+ */
 export const Basic: StoryObj = {
   render: () => <Tag color={Tag.colors.green}>Foo</Tag>
 };
-
-Utils.story(Basic, {
-  desc: `
-A tag requires a label, defined as a string via the \`children\` prop, and a
-color, defined via the same name prop, and should come from the \`Tag.colors\`
-list. You can try all available colors in the [All Props][1] table below.
-
-[1]: #props
-`,
-});

--- a/src/docs/components/tag.stories.tsx
+++ b/src/docs/components/tag.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Utils } from "../utils/utils";
 import { Tag } from "../../core";
 import { docsMetaParameters } from "../utils/parameter";
 import { GalleryTag } from "../../gallery";
+import { docsMetaArgTypes } from "../utils/arg-type";
 
 const meta: Meta = {
   title: "Components/Tag",
@@ -10,12 +10,14 @@ const meta: Meta = {
   parameters: docsMetaParameters({
     gallery: <GalleryTag />
   }),
-  argTypes: {
-    children: Utils.arg(null),
-    color: Utils.arg(Tag.colors),
-    size: Utils.arg(Tag.sizes),
-    forwardedRef: Utils.arg(null),
-  },
+  argTypes: docsMetaArgTypes({
+    "": {
+      children: false,
+      color: Tag.colors,
+      size: Tag.sizes,
+      forwardedRef: false,
+    }
+  })
 };
 
 export default meta;

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -27,14 +27,14 @@ export const Primary: StoryObj<typeof Tooltip> = {
 
 /**
  * To have a tooltip for an element, wrap the `Tooltip` component outside it,
- * and define the information via the `content` prop. The tooltip is shown when
- * users hover or focus on the element.
+ * and define the information via the `content` prop.
+ * The tooltip is shown when users hover or focus on the element.
  * 
- * To have your tooltips [accessible][1] to all users, even those who don't use a
- * mouse, ensure your elements are [focusable][2]. For example, if it's a
- * non-interactive element like a `<span>`, you may want to use
- * `tabIndex={0}`. You don't need to do anything for interactive elements like
- * buttons and inputs.
+ * To have your tooltips [accessible][1] to all users, even those who don't use a mouse,
+ * ensure your elements are [focusable][2].
+ * For example, if it's a non-interactive element like a `<span>`,
+ * you may want to use `tabIndex={0}`.
+ * You don't need to do anything for interactive elements like buttons and inputs.
  * 
  * [1]: https://www.nngroup.com/articles/tooltip-guidelines/
  * [2]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#interactive_elements_must_be_focusable
@@ -48,14 +48,15 @@ export const Basic: StoryObj = {
 };
 
 /**
- * By default, Tooltip positions the `content` on top of the `children`. This
- * can be changed via the `placement` prop, which expects a string of [Tippy.js'
- * `placement`][1] option. You can see (and try!) all available placements at
- * the [props table][2] below.
+ * By default, Tooltip positions the `content` on top of the `children`.
+ * This can be changed via the `placement` prop,
+ * which expects a string of [Tippy.js' `placement`][1] option.
+ * You can see (and try!) all available placements at the [props table][2] below.
  * 
- * Note that this is more like a suggestion. If there is no space in the selected
- * placement, Tooltip will choose another placement, usually the opposite
- * one, to keep the content in the viewport.
+ * Note that this is more like a suggestion.
+ * If there is no space in the selected placement,
+ * Tooltip will choose another placement, usually the opposite one,
+ * to keep the content in the viewport.
  * 
  * [1]: https://atomiks.github.io/tippyjs/v6/all-props/#placement
  * [2]: #props

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -25,6 +25,20 @@ export const Primary: StoryObj<typeof Tooltip> = {
   )
 };
 
+/**
+ * To have a tooltip for an element, wrap the `Tooltip` component outside it,
+ * and define the information via the `content` prop. The tooltip is shown when
+ * users hover or focus on the element.
+ * 
+ * To have your tooltips [accessible][1] to all users, even those who don't use a
+ * mouse, ensure your elements are [focusable][2]. For example, if it's a
+ * non-interactive element like a `<span>`, you may want to use
+ * `tabIndex={0}`. You don't need to do anything for interactive elements like
+ * buttons and inputs.
+ * 
+ * [1]: https://www.nngroup.com/articles/tooltip-guidelines/
+ * [2]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#interactive_elements_must_be_focusable
+ */
 export const Basic: StoryObj = {
   render: () => (
     <Tooltip content="Hello Moai">
@@ -33,44 +47,24 @@ export const Basic: StoryObj = {
   )
 };
 
-Utils.story(Basic, {
-  desc: `
-To have a tooltip for an element, wrap the \`Tooltip\` component outside it,
-and define the information via the \`content\` prop. The tooltip is shown when
-users hover or focus on the element.
-
-To have your tooltips [accessible][1] to all users, even those who don't use a
-mouse, ensure your elements are [focusable][2]. For example, if it's a
-non-interactive element like a \`<span>\`, you may want to use
-\`tabIndex={0}\`. You don't need to do anything for interactive elements like
-buttons and inputs.
-
-[1]: https://www.nngroup.com/articles/tooltip-guidelines/
-[2]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#interactive_elements_must_be_focusable
-`,
-});
-
+/**
+ * By default, Tooltip positions the `content` on top of the `children`. This
+ * can be changed via the `placement` prop, which expects a string of [Tippy.js'
+ * `placement`][1] option. You can see (and try!) all available placements at
+ * the [props table][2] below.
+ * 
+ * Note that this is more like a suggestion. If there is no space in the selected
+ * placement, Tooltip will choose another placement, usually the opposite
+ * one, to keep the content in the viewport.
+ * 
+ * [1]: https://atomiks.github.io/tippyjs/v6/all-props/#placement
+ * [2]: #props
+ */
 export const PlacementExample: StoryObj = {
+  name: 'Placement',
   render: () => (
     <Tooltip content="Hello Moai" placement="right">
       <span tabIndex={0}>Hover me</span>
     </Tooltip>
   )
 };
-
-Utils.story(PlacementExample, {
-  name: "Placement",
-  desc: `
-By default, Tooltip positions the \`content\` on top of the \`children\`. This
-can be changed via the \`placement\` prop, which expects a string of [Tippy.js'
-\`placement\`][1] option. You can see (and try!) all available placements at
-the [props table][2] below.
-
-Note that this is more like a suggestion. If there is no space in the selected
-placement, Tooltip will choose another placement, usually the opposite
-one, to keep the content in the viewport.
-
-[1]: https://atomiks.github.io/tippyjs/v6/all-props/#placement
-[2]: #props
-`,
-});

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -13,8 +13,6 @@ const meta: Meta = {
   },
 };
 
-Utils.page.component(meta, { primary: "sticky", shots: [] });
-
 export default meta;
 
 export const Primary: StoryObj<typeof Tooltip> = {

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta } from "@storybook/react";
-import { Tooltip, TooltipProps } from "../../../core/src";
+import { Meta, StoryObj } from "@storybook/react";
 import { PLACEMENTS } from "../utils/placement";
 import { Utils } from "../utils/utils";
+import { Tooltip } from "../../core";
 
 const meta: Meta = {
   title: "Components/Tooltip",
@@ -17,21 +17,21 @@ Utils.page.component(meta, { primary: "sticky", shots: [] });
 
 export default meta;
 
-interface Props {
-  placement?: TooltipProps["placement"];
-}
+export const Primary: StoryObj<typeof Tooltip> = {
+  render: (props) => (
+    <Tooltip content="Hello Moai" placement={props.placement}>
+      <span tabIndex={0}>Hover me</span>
+    </Tooltip>
+  )
+};
 
-export const Primary = (props: Props): JSX.Element => (
-  <Tooltip content="Hello Moai" placement={props.placement}>
-    <span tabIndex={0}>Hover me</span>
-  </Tooltip>
-);
-
-export const Basic = (): JSX.Element => (
-  <Tooltip content="Hello Moai">
-    <span tabIndex={0}>Hover me</span>
-  </Tooltip>
-);
+export const Basic: StoryObj = {
+  render: () => (
+    <Tooltip content="Hello Moai">
+      <span tabIndex={0}>Hover me</span>
+    </Tooltip>
+  )
+};
 
 Utils.story(Basic, {
   desc: `
@@ -50,11 +50,13 @@ buttons and inputs.
 `,
 });
 
-export const PlacementExample = (): JSX.Element => (
-  <Tooltip content="Hello Moai" placement="right">
-    <span tabIndex={0}>Hover me</span>
-  </Tooltip>
-);
+export const PlacementExample: StoryObj = {
+  render: () => (
+    <Tooltip content="Hello Moai" placement="right">
+      <span tabIndex={0}>Hover me</span>
+    </Tooltip>
+  )
+};
 
 Utils.story(PlacementExample, {
   name: "Placement",

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -1,0 +1,74 @@
+import { Meta } from "@storybook/react";
+import { Tooltip, TooltipProps } from "../../../core/src";
+import { PLACEMENTS } from "../utils/placement";
+import { Utils } from "../utils/utils";
+
+const meta: Meta = {
+  title: "Components/Tooltip",
+  component: Tooltip,
+  argTypes: {
+    placement: Utils.arg(PLACEMENTS),
+    content: Utils.arg(null),
+    children: Utils.arg(null),
+  },
+};
+
+Utils.page.component(meta, { primary: "sticky", shots: [] });
+
+export default meta;
+
+interface Props {
+  placement?: TooltipProps["placement"];
+}
+
+export const Primary = (props: Props): JSX.Element => (
+  <Tooltip content="Hello Moai" placement={props.placement}>
+    <span tabIndex={0}>Hover me</span>
+  </Tooltip>
+);
+
+export const Basic = (): JSX.Element => (
+  <Tooltip content="Hello Moai">
+    <span tabIndex={0}>Hover me</span>
+  </Tooltip>
+);
+
+Utils.story(Basic, {
+  desc: `
+To have a tooltip for an element, wrap the \`Tooltip\` component outside it,
+and define the information via the \`content\` prop. The tooltip is shown when
+users hover or focus on the element.
+
+To have your tooltips [accessible][1] to all users, even those who don't use a
+mouse, ensure your elements are [focusable][2]. For example, if it's a
+non-interactive element like a \`<span>\`, you may want to use
+\`tabIndex={0}\`. You don't need to do anything for interactive elements like
+buttons and inputs.
+
+[1]: https://www.nngroup.com/articles/tooltip-guidelines/
+[2]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#interactive_elements_must_be_focusable
+`,
+});
+
+export const PlacementExample = (): JSX.Element => (
+  <Tooltip content="Hello Moai" placement="right">
+    <span tabIndex={0}>Hover me</span>
+  </Tooltip>
+);
+
+Utils.story(PlacementExample, {
+  name: "Placement",
+  desc: `
+By default, Tooltip positions the \`content\` on top of the \`children\`. This
+can be changed via the \`placement\` prop, which expects a string of [Tippy.js'
+\`placement\`][1] option. You can see (and try!) all available placements at
+the [props table][2] below.
+
+Note that this is more like a suggestion. If there is no space in the selected
+placement, Tooltip will choose another placement, usually the opposite
+one, to keep the content in the viewport.
+
+[1]: https://atomiks.github.io/tippyjs/v6/all-props/#placement
+[2]: #props
+`,
+});

--- a/src/docs/components/tooltip.stories.tsx
+++ b/src/docs/components/tooltip.stories.tsx
@@ -1,16 +1,18 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { PLACEMENTS } from "../utils/placement";
-import { Utils } from "../utils/utils";
 import { Tooltip } from "../../core";
+import { docsMetaArgTypes } from "../utils/arg-type";
+import { PLACEMENTS } from "../utils/placement";
 
 const meta: Meta = {
   title: "Components/Tooltip",
   component: Tooltip,
-  argTypes: {
-    placement: Utils.arg(PLACEMENTS),
-    content: Utils.arg(null),
-    children: Utils.arg(null),
-  },
+  argTypes: docsMetaArgTypes({
+    "": {
+      placement: PLACEMENTS,
+      content: false,
+      children: false,
+    }
+  })
 };
 
 export default meta;

--- a/src/docs/utils/arg-type.ts
+++ b/src/docs/utils/arg-type.ts
@@ -24,19 +24,21 @@ type RawGroup<CT extends ComponentType> = Partial<
 >;
 
 const transformValue = (value: DocsValue): RawValue => {
-  switch (value) {
-    case false:
+  switch (true) {
+    case value === false:
       return { control: false };
-    case "boolean":
+    case value === "boolean":
       return { control: "boolean" };
-    case "number":
+    case value === "number":
       return { control: "number" };
+    case Array.isArray(value):
+      return { control: "select", options: value, };
+    case typeof value === "object": {
+      const options = Object.keys(value);
+      return { control: "select", mapping: value, options, };
+    }
     default:
-      return {
-        control: "select",
-        mapping: value,
-        options: Object.keys(value),
-      };
+      throw new Error(`Invalid value: ${value}`);
   }
 };
 

--- a/src/docs/utils/arg-type.ts
+++ b/src/docs/utils/arg-type.ts
@@ -1,7 +1,7 @@
 import { ArgTypes } from "@storybook/react";
 import { ComponentProps, ComponentType } from "react";
 
-type DocsValue = false | "boolean" | object;
+type DocsValue = false | "boolean" | "number" | object;
 
 type DocsGroup<CT extends ComponentType> = Partial<
   Record<keyof ComponentProps<CT>, DocsValue>
@@ -29,6 +29,8 @@ const transformValue = (value: DocsValue): RawValue => {
       return { control: false };
     case "boolean":
       return { control: "boolean" };
+    case "number":
+      return { control: "number" };
     default:
       return {
         control: "select",

--- a/src/docs/utils/placement.ts
+++ b/src/docs/utils/placement.ts
@@ -1,0 +1,19 @@
+import { PopoverPlacement } from "../../core";
+
+export const PLACEMENTS: PopoverPlacement[] = [
+  "top",
+  "top-start",
+  "top-end",
+  "right",
+  "right-start",
+  "right-end",
+  "bottom",
+  "bottom-start",
+  "bottom-end",
+  "left",
+  "left-start",
+  "left-end",
+  "auto",
+  "auto-start",
+  "auto-end",
+];


### PR DESCRIPTION
### Background

Restore docs for the following components: Pagination, Pane, ProgressCircle, Tag and Tooltip

### References

https://github.com/thien-do/moai/issues/304

### Test

Component | Doc
--|--
Pagination | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/f6adfe6a-7b84-4673-aa39-334e99163438" />
Pane | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/8996bf70-e18f-4582-8dc0-ef7df8d642c7" />
ProgressCircle | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/f6f3124d-ab26-4a92-a619-5db86d1a931b" />
Tag | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/616980ab-a85c-4c2b-958a-2c5db5c66677" />
Tooltip | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/97ede0db-c91c-4255-b7c3-f04239dceba9" />
